### PR TITLE
Implement getACL() for Node

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,16 +10,16 @@
 
     <artifactId>role-strategy</artifactId>
     <packaging>hpi</packaging>
-    <version>3.2.0</version>
+    <version>3.2.1-cermati</version>
     <name>Role-based Authorization Strategy</name>
     <url>https://github.com/jenkinsci/role-strategy-plugin</url>
 
-    <scm>
+    <!-- <scm>
         <connection>scm:git:ssh://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-        <tag>role-strategy-3.2.0</tag>
-    </scm>
+        <tag>role-strategy-3.2.1-cermati</tag>
+    </scm> -->
 
     <developers>
         <developer>
@@ -40,7 +40,7 @@
     </developers>
 
     <properties>
-        <revision>3.2.1</revision>
+        <revision>3.2.2</revision>
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.222.4</jenkins.version>
         <java.level>8</java.level>

--- a/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/rolestrategy/RoleBasedAuthorizationStrategy.java
@@ -40,6 +40,7 @@ import hudson.model.Hudson;
 import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.Run;
+import hudson.model.Node;
 import hudson.model.View;
 import hudson.scm.SCM;
 import hudson.security.ACL;
@@ -61,6 +62,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.regex.Pattern;
@@ -174,6 +176,17 @@ public class RoleBasedAuthorizationStrategy extends AuthorizationStrategy {
     public ACL getACL(@Nonnull Computer computer) {
         return agentRoles.newMatchingRoleMap(computer.getName()).getACL(RoleType.Slave, computer)
                 .newInheritingACL(getRootACL());
+    }
+
+    @Override
+    @Nonnull
+    public ACL getACL(@Nonnull Node node) {
+      Computer nodeComputer = node.toComputer();
+      if (Objects.isNull(nodeComputer)) {
+        throw new IllegalArgumentException(String.format("Cannot convert node '%s' into a Computer instance", node.getNodeName()));
+      }
+
+      return this.getACL(nodeComputer);
     }
 
   /**

--- a/src/test/java/org/jenkinsci/plugins/rolestrategy/RoleStrategyTest.java
+++ b/src/test/java/org/jenkinsci/plugins/rolestrategy/RoleStrategyTest.java
@@ -104,9 +104,13 @@ public class RoleStrategyTest {
         assertHasPermission(admin, agent1, Computer.CONFIGURE, Computer.DELETE, Computer.BUILD);
         assertHasPermission(user1, agent1, Computer.BUILD);
         assertHasNoPermission(user1, agent1, Computer.CONFIGURE, Computer.DISCONNECT);
+        assertHasPermission(admin, agent1.getNode(), Computer.CONFIGURE, Computer.DELETE, Computer.BUILD);
+        assertHasPermission(user1, agent1.getNode(), Computer.BUILD);
+        assertHasNoPermission(user1, agent1.getNode(), Computer.CONFIGURE, Computer.DISCONNECT);
 
         // Same user still cannot build on agent2
         assertHasNoPermission(user1, agent2, Computer.BUILD);
+        assertHasNoPermission(user1, agent2.getNode(), Computer.BUILD);
     }
 
     @Test


### PR DESCRIPTION
Implement `RoleBasedAuthorizationStrategy.getACL()` for `hudson.model.Node`, fixing issue described in [JENKINS-56834](https://issues.jenkins.io/browse/JENKINS-56834). Implementation based on https://github.com/jenkinsci/role-strategy-plugin/pull/59.

Note that build authorization for the master node does not work; `getACL()` is not called for jobs targeting the master node.

Tested against Jenkins v2.322.2 with the following plugins installed:
  - `cloudbees-folder:6.714.v79e858ef76a_2`
  - `antisamy-markup-formatter:2.7`
  - `build-timeout:1.20`
  - `credentials-binding:523.vd859a_4b_122e6`
  - `timestamper:1.17`
  - `ws-cleanup:0.42`
  - `workflow-aggregator:2.7`
  - `github-branch-source:1598.v91207e9f9b_4a_`
  - `pipeline-github-lib:36.v4c01db_ca_ed16`
  - `pipeline-stage-view:2.24`
  - `git:4.11.1`
  - `ssh-slaves:1.814.vc82988f54b_10`
  - `matrix-auth:2.6.11`
  - `authorize-project:1.4.0`
  - `reverse-proxy-auth-plugin:1.7.3`

To run the tests and build the plugin, run `/path/to/apache-maven-3.8.5/bin/mvn install`. The plugin will be built as `target/role-strategy.hpi`.
